### PR TITLE
Add CLAUDE.md to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ bld/
 
 # Claude
 .claude/
+CLAUDE.md
 
 # VS Code
 .vscode/


### PR DESCRIPTION
Prevents CLAUDE.md (Claude Code instruction file) from being committed to the repository. This file contains local development instructions and should remain local only.