### PR TITLE
fix: Move LanguageSelector JS interop to OnAfterRenderAsync

### DIFF
--- a/src/CoralLedger.Blue.Web/Components/Shared/LanguageSelector.razor
+++ b/src/CoralLedger.Blue.Web/Components/Shared/LanguageSelector.razor
@@ -13,7 +13,8 @@
 
 @code {
     private string _currentCulture = "en";
-    
+    private bool _initialized;
+
     private readonly List<CultureOption> _supportedCultures = new()
     {
         new CultureOption { Code = "en", DisplayName = "English" },
@@ -21,10 +22,16 @@
         new CultureOption { Code = "ht", DisplayName = "Kreyòl" }
     };
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        // Get current culture from cookie using safe helper function
-        _currentCulture = await JS.InvokeAsync<string>("localization.getCurrentCulture");
+        if (firstRender && !_initialized)
+        {
+            _initialized = true;
+            // Get current culture from cookie using safe helper function
+            // Must be in OnAfterRenderAsync because JS interop is not available during prerendering
+            _currentCulture = await JS.InvokeAsync<string>("localization.getCurrentCulture");
+            StateHasChanged();
+        }
     }
 
     private async Task OnCultureChanged(object value)


### PR DESCRIPTION
## Summary
Fixes critical bug introduced in PR #51 where the LanguageSelector component called JS interop in `OnInitializedAsync()`, which fails during Blazor prerendering.

## Problem
When loading any page with the LanguageSelector component, the server returned HTTP 500:
```
System.InvalidOperationException: JavaScript interop calls cannot be issued at this time. 
This is because the component is being statically rendered.
```

## Solution
Moved the JS interop call from `OnInitializedAsync()` to `OnAfterRenderAsync(bool firstRender)`, which is the correct lifecycle method for JS interop in Blazor.

## Testing
- Build: Succeeded
- Unit/Integration tests: 679 passed
- E2E tests: 76/79 passed (3 failing due to separate localization resource loading issue)

## Changes
- `LanguageSelector.razor`: Move `JS.InvokeAsync` call to `OnAfterRenderAsync`